### PR TITLE
tktable 2.10: x11_gui_rebuilds

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/tk-feedstock/pr11/0aa4a9f

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/tk-feedstock/pr11/69c15fa

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/tk-feedstock/pr11/0aa4a9f
+  - https://staging.continuum.io/prefect/fs/tk-feedstock/pr11/69c15fa

--- a/recipe/0002-Fix-incompatible-function-pointer-types-add-CONST86.patch
+++ b/recipe/0002-Fix-incompatible-function-pointer-types-add-CONST86.patch
@@ -1,0 +1,128 @@
+From 517fa24afda62237bdb4d3de126769f40c853bfe Mon Sep 17 00:00:00 2001
+From: Marcel Bargull <marcel.bargull@udo.edu>
+Date: Sat, 22 Jun 2024 14:40:27 +0000
+Subject: [PATCH] Fix incompatible-function-pointer-types, add CONST86
+
+---
+ generic/tkTable.h     | 7 +++++--
+ generic/tkTableTag.c  | 4 ++--
+ generic/tkTableUtil.c | 8 ++++----
+ generic/tkTableWin.c  | 4 ++--
+ 4 files changed, 13 insertions(+), 10 deletions(-)
+
+diff --git a/generic/tkTable.h b/generic/tkTable.h
+index cfb83e7..827debb 100644
+--- a/generic/tkTable.h
++++ b/generic/tkTable.h
+@@ -40,6 +40,9 @@
+ #ifndef CONST84
+ #  define CONST84
+ #endif
++#ifndef CONST86
++# define CONST86 CONST84
++#endif
+ 
+ /* This EXTERN declaration is needed for Tcl < 8.0.3 */
+ #ifndef EXTERN
+@@ -526,7 +529,7 @@ extern void	Table_ClearHashTable(Tcl_HashTable *hashTblPtr);
+ extern int	TableOptionBdSet(ClientData clientData,
+ 			Tcl_Interp *interp, Tk_Window tkwin,
+ 			CONST84 char *value, char *widgRec, int offset);
+-extern char *	TableOptionBdGet(ClientData clientData,
++extern CONST86 char *	TableOptionBdGet(ClientData clientData,
+ 			Tk_Window tkwin, char *widgRec, int offset,
+ 			Tcl_FreeProc **freeProcPtr);
+ extern int	TableTagConfigureBd(Table *tablePtr,
+@@ -535,7 +538,7 @@ extern int	Cmd_OptionSet(ClientData clientData,
+ 			Tcl_Interp *interp,
+ 			Tk_Window unused, CONST84 char *value,
+ 			char *widgRec, int offset);
+-extern char *	Cmd_OptionGet(ClientData clientData,
++extern CONST86 char *	Cmd_OptionGet(ClientData clientData,
+ 			Tk_Window unused, char *widgRec,
+ 			int offset, Tcl_FreeProc **freeProcPtr);
+ 
+diff --git a/generic/tkTableTag.c b/generic/tkTableTag.c
+index 028984a..520eeed 100644
+--- a/generic/tkTableTag.c
++++ b/generic/tkTableTag.c
+@@ -22,7 +22,7 @@ static void	TableImageProc _ANSI_ARGS_((ClientData clientData, int x,
+ static int	TableOptionReliefSet _ANSI_ARGS_((ClientData clientData,
+ 			Tcl_Interp *interp, Tk_Window tkwin,
+ 			CONST84 char *value, char *widgRec, int offset));
+-static char *	TableOptionReliefGet _ANSI_ARGS_((ClientData clientData,
++static CONST86 char *	TableOptionReliefGet _ANSI_ARGS_((ClientData clientData,
+ 			Tk_Window tkwin, char *widgRec, int offset,
+ 			Tcl_FreeProc **freeProcPtr));
+ 
+@@ -1340,7 +1340,7 @@ TableOptionReliefSet(clientData, interp, tkwin, value, widgRec, offset)
+  *----------------------------------------------------------------------
+  */
+ 
+-static char *
++static CONST86 char *
+ TableOptionReliefGet(clientData, tkwin, widgRec, offset, freeProcPtr)
+     ClientData clientData;		/* Type of struct being set. */
+     Tk_Window tkwin;			/* Window containing canvas widget. */
+diff --git a/generic/tkTableUtil.c b/generic/tkTableUtil.c
+index 5e5e9d0..4587b75 100644
+--- a/generic/tkTableUtil.c
++++ b/generic/tkTableUtil.c
+@@ -13,7 +13,7 @@
+ 
+ #include "tkTable.h"
+ 
+-static char *	Cmd_GetName _ANSI_ARGS_((const Cmd_Struct *cmds, int val));
++static CONST86 char *	Cmd_GetName _ANSI_ARGS_((const Cmd_Struct *cmds, int val));
+ static int	Cmd_GetValue _ANSI_ARGS_((const Cmd_Struct *cmds,
+ 			const char *arg));
+ static void	Cmd_GetError _ANSI_ARGS_((Tcl_Interp *interp,
+@@ -169,7 +169,7 @@ TableOptionBdSet(clientData, interp, tkwin, value, widgRec, offset)
+  *----------------------------------------------------------------------
+  */
+ 
+-char *
++CONST86 char *
+ TableOptionBdGet(clientData, tkwin, widgRec, offset, freeProcPtr)
+     ClientData clientData;		/* Type of struct being set. */
+     Tk_Window tkwin;			/* Window containing canvas widget. */
+@@ -329,7 +329,7 @@ Cmd_OptionSet(ClientData clientData, Tcl_Interp *interp,
+  *----------------------------------------------------------------------
+  */
+ 
+-char *
++CONST86 char *
+ Cmd_OptionGet(ClientData clientData, Tk_Window unused,
+ 	      char *widgRec, int offset, Tcl_FreeProc **freeProcPtr)
+ {
+@@ -342,7 +342,7 @@ Cmd_OptionGet(ClientData clientData, Tk_Window unused,
+  * simple Cmd_Struct lookup functions
+  */
+ 
+-char *
++CONST86 char *
+ Cmd_GetName(const Cmd_Struct *cmds, int val)
+ {
+   for(;cmds->name && cmds->name[0];cmds++) {
+diff --git a/generic/tkTableWin.c b/generic/tkTableWin.c
+index 86e1c0c..40a1b27 100644
+--- a/generic/tkTableWin.c
++++ b/generic/tkTableWin.c
+@@ -17,7 +17,7 @@
+ static int	StickyParseProc _ANSI_ARGS_((ClientData clientData,
+ 			Tcl_Interp *interp, Tk_Window tkwin,
+ 			CONST84 char *value, char *widgRec, int offset));
+-static char *	StickyPrintProc _ANSI_ARGS_((ClientData clientData,
++static CONST86 char *	StickyPrintProc _ANSI_ARGS_((ClientData clientData,
+ 			Tk_Window tkwin, char *widgRec, int offset,
+ 			Tcl_FreeProc **freeProcPtr));
+ 
+@@ -117,7 +117,7 @@ static Tk_ConfigSpec winConfigSpecs[] = {
+  *
+  *----------------------------------------------------------------------
+  */
+-static char *
++static CONST86 char *
+ StickyPrintProc(clientData, tkwin, widgRec, offset, freeProcPtr)
+     ClientData clientData;		/* Ignored. */
+     Tk_Window tkwin;			/* Window for text widget. */

--- a/recipe/0003-Fix-implicit-function-declaration-for-panic-on-macOS.patch
+++ b/recipe/0003-Fix-implicit-function-declaration-for-panic-on-macOS.patch
@@ -1,0 +1,42 @@
+From d48690d6abda64efdb48aa91e7f960c237a94b49 Mon Sep 17 00:00:00 2001
+From: Marcel Bargull <marcel.bargull@udo.edu>
+Date: Sat, 22 Jun 2024 15:15:52 +0000
+Subject: [PATCH] Fix implicit-function-declaration for panic on macOS
+
+---
+ generic/tkTableTag.c  | 5 +++++
+ generic/tkTableUtil.c | 5 +++++
+ 2 files changed, 10 insertions(+)
+
+diff --git a/generic/tkTableTag.c b/generic/tkTableTag.c
+index 520eeed..5506394 100644
+--- a/generic/tkTableTag.c
++++ b/generic/tkTableTag.c
+@@ -13,6 +13,11 @@
+ 
+ #include "tkTable.h"
+ 
++#if defined(__APPLE__) && !defined(panic)
++/* On macOS, tcl.h does not #define panic Tcl_Panic. */
++# include <mach/mach.h>
++#endif
++
+ static TableTag *TableTagGetEntry _ANSI_ARGS_((Table *tablePtr, char *name,
+ 	int objc, CONST char **argv));
+ static unsigned int	TableTagGetPriority _ANSI_ARGS_((Table *tablePtr,
+diff --git a/generic/tkTableUtil.c b/generic/tkTableUtil.c
+index 4587b75..8627ce6 100644
+--- a/generic/tkTableUtil.c
++++ b/generic/tkTableUtil.c
+@@ -13,6 +13,11 @@
+ 
+ #include "tkTable.h"
+ 
++#if defined(__APPLE__) && !defined(panic)
++/* On macOS, tcl.h does not #define panic Tcl_Panic. */
++# include <mach/mach.h>
++#endif
++
+ static CONST86 char *	Cmd_GetName _ANSI_ARGS_((const Cmd_Struct *cmds, int val));
+ static int	Cmd_GetValue _ANSI_ARGS_((const Cmd_Struct *cmds,
+ 			const char *arg));

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,10 +24,7 @@ requirements:
     - m2-patch  # [win]
   host:
     - tk {{ tk }}
-    - xorg-xorgproto  # [linux]
     - xorg-libx11  # [linux]
-    - xorg-libxau  # [linux]
-    - libxcb  # [linux]
   run:
     - tk
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,9 +8,11 @@ package:
 source:
   url: http://downloads.sourceforge.net/project/{{ name }}/{{ name }}/{{ version }}/Tktable{{ version }}.tar.gz
   sha256: c335117fa1be45fe4d3032e96fd4b4641fff6a4f8467878608dabed11198a4cb
-  patches:  # [win]
+  patches:
     # To fix an error "LINK : fatal error LNK1181: cannot open input file 'C:\build\tcl84-64\tclstub86.lib'"
     - 0001-Remove-hardcoded-libs_1.patch  # [win]
+    - 0002-Fix-incompatible-function-pointer-types-add-CONST86.patch
+    - 0003-Fix-implicit-function-declaration-for-panic-on-macOS.patch  # [osx]
 
 build:
   number: 2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - m2-patch  # [win]
   host:
     - tk {{ tk }}
-    - xorg-libx11  # [linux]
+    - xorg-libx11 {{ xorg_libx11 }}  # [linux]
   run:
     - tk
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,19 +13,18 @@ source:
     - 0001-Remove-hardcoded-libs_1.patch  # [win]
 
 build:
-  number: 3
+  number: 2
 
 requirements:
   build:
     - {{ compiler('c') }}
-    # TODO: map CDT libxau to new X11 package
-    # - { cdt('libxau') }
     - make  # [linux]
     - m2-patch  # [win]
   host:
     - tk {{ tk }}
     - xorg-xproto
     - xorg-libx11
+    - xorg-libxau
     - libxcb
   run:
     - tk

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,32 +8,33 @@ package:
 source:
   url: http://downloads.sourceforge.net/project/{{ name }}/{{ name }}/{{ version }}/Tktable{{ version }}.tar.gz
   sha256: c335117fa1be45fe4d3032e96fd4b4641fff6a4f8467878608dabed11198a4cb
-  patches:                              # [win]
+  patches:  # [win]
     # To fix an error "LINK : fatal error LNK1181: cannot open input file 'C:\build\tcl84-64\tclstub86.lib'"
     - 0001-Remove-hardcoded-libs_1.patch  # [win]
 
 build:
-  number: 1
+  number: 3
 
 requirements:
   build:
     - {{ compiler('c') }}
-    - {{ cdt('xorg-x11-proto-devel') }}  # [linux]
-    - {{ cdt('libx11-devel') }}          # [linux]
-    - {{ cdt('libxcb') }}                # [linux]
-    - {{ cdt('libxau') }}                # [linux]
-    - make                               # [linux]
-    - m2-patch                           # [win]
+    # TODO: map CDT libxau to new X11 package
+    # - { cdt('libxau') }
+    - make  # [linux]
+    - m2-patch  # [win]
   host:
     - tk {{ tk }}
+    - xorg-xproto
+    - xorg-libx11
+    - libxcb
   run:
     - tk
 
 test:
   commands:
     - echo "if {[catch {package require -exact Tktable {{ version }}; exit 0}]} {exit 1}" | xvfb-run tclsh  # [linux]
-    - echo "if {[catch {package require -exact Tktable {{ version }}; exit 0}]} {exit 1}" | tclsh           # [osx]
-    - echo if {[catch {package require -exact Tktable {{ version }}; exit 0}]} {exit 1} | tclsh             # [win]
+    - echo "if {[catch {package require -exact Tktable {{ version }}; exit 0}]} {exit 1}" | tclsh  # [osx]
+    - echo if {[catch {package require -exact Tktable {{ version }}; exit 0}]} {exit 1} | tclsh  # [win]
 
 about:
   home: https://www.tcl.tk/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - make  # [linux]
+    - patch     # [not win] 
     - m2-patch  # [win]
   host:
     - tk {{ tk }}
@@ -35,7 +36,7 @@ test:
     - echo if {[catch {package require -exact Tktable {{ version }}; exit 0}]} {exit 1} | tclsh  # [win]
 
 about:
-  home: https://www.tcl.tk/
+  home: https://www.tcl.tk
   license: TCL
   license_family: BSD
   license_file: license.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,10 +22,10 @@ requirements:
     - m2-patch  # [win]
   host:
     - tk {{ tk }}
-    - xorg-xproto
-    - xorg-libx11
-    - xorg-libxau
-    - libxcb
+    - xorg-xorgproto  # [linux]
+    - xorg-libx11  # [linux]
+    - xorg-libxau  # [linux]
+    - libxcb  # [linux]
   run:
     - tk
 


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7783](https://anaconda.atlassian.net/browse/PKG-7783)
- [Upstream repository](https://sourceforge.net/projects/tktable/)

### Explanation of changes:

- Replace CTDs with xorg-libx11
- Get patches from the conda-forge recipe

### Notes:

- Automated migration/rebuild for group x11_gui_rebuilds.


[PKG-7783]: https://anaconda.atlassian.net/browse/PKG-7783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ